### PR TITLE
記事一覧ページの表示修正

### DIFF
--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,19 +1,19 @@
-.column.is-one-third
-  div id="post-id-#{post.id}"
-    .card
-      .card-image
-        figure.image.is-4by3
-          = image_tag post.images.first.image_url, size: '300x200', alt: 'post-img'
-          / img[src="https://bulma.io/images/placeholders/1280x960.png" alt="Placeholder image"]
-      .card-content
-        .media
-          .media-content
-            p.title.is-4
-              | #{post.user.name}
-        .content
-          p 車名 : #{post.car_name}
-          p 型式 : #{post.car_model}
-          p ナンバープレート : #{post.car_number}
-          p 盗難場所 : #{post.stole_location}
-          p 盗難日時 : #{post.stole_time}
-          p 連絡先 : #{post.contact}
+.column.is-multiline.is-mobile.is-one-third-desktop.is-half-mobile
+  .card
+    div id="post-id-#{post.id}"
+      = link_to post_path(post)
+        .card-image
+          figure.image.is-4by3
+            = image_tag post.images.first.image_url, size: '300x200', alt: 'post-img'
+        .card-content
+          .media
+            .media-content
+              p.title.is-4
+                | #{post.user.name}
+          .content
+            p 車名 : #{post.car_name}
+            p 型式 : #{post.car_model}
+            p ナンバープレート : #{post.car_number}
+            p 盗難場所 : #{post.stole_location}
+            p 盗難日時 : #{post.stole_time}
+            p 連絡先 : #{post.contact}

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,3 +1,3 @@
-.container.pt-3
-  .columns
+.container.pt-3.is-centered
+  .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
     = render @posts


### PR DESCRIPTION
Resolves #41 
記事一覧ページで、全ての記事が横一列に並んでいたのを3記事で改行されるように変更[![Image from Gyazo](https://i.gyazo.com/78803c1964eee85db2988a6639a25c05.png)](https://gyazo.com/78803c1964eee85db2988a6639a25c05)
[![Image from Gyazo](https://i.gyazo.com/d90182bd1949d441cd2e12fc4edde0e2.png)](https://gyazo.com/d90182bd1949d441cd2e12fc4edde0e2)
スマホ対応はできていないので、今後要修正